### PR TITLE
Dependabot for upgrade branch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+version: 2
+updates:
+  - package-ecosystem: maven
+    directory: /
+    open-pull-requests-limit: 10
+    target-branch: upgrade
+    schedule:
+      interval: daily
+
+  - package-ecosystem: github-actions
+    directory: /
+    open-pull-requests-limit: 10
+    target-branch: upgrade
+    schedule:
+      interval: daily


### PR DESCRIPTION
Turn on dependabot for the `upgrade` branch. NOTE: `dependabot.yml` MUST live on the repo's default branch (`master` in this case).